### PR TITLE
toBuffer() of data urls with url encoded data decodes value

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = (s) => {
   parsed.toBuffer = () => {
     const encoding = parsed.base64 ? 'base64' : 'utf8';
 
-    return Buffer.from(parsed.data, encoding);
+    return Buffer.from(parsed.base64 ? parsed.data : decodeURIComponent(parsed.data), encoding);
   };
 
   return parsed;

--- a/test.js
+++ b/test.js
@@ -48,6 +48,7 @@ describe('parse-data-url', () => {
     expect(parsed.base64).equal(false);
     expect(parsed.charset).be.an('undefined');
     expect(parsed.data).to.equal('%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E');
+    expect(parsed.toBuffer().toString()).to.equal('<h1>Hello, World!</h1>');
   });
 
   it('parse with empty data ', () => {
@@ -120,9 +121,8 @@ describe('parse-data-url', () => {
 
   it('export buffer from parsed data with utf-8', () => {
     parsed = parseDataUrl('data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E');
-    const buffer = Buffer.from(parsed.data, 'utf8');
     const parsedBuffer = parsed.toBuffer();
-    expect(buffer.equals(parsedBuffer)).equal(true);
+    expect(parsedBuffer.toString()).to.equal('<h1>Hello, World!</h1>');
   });
 
   it('export buffer from parsed data with empty data', () => {


### PR DESCRIPTION
`parse-data-url` does not decode the data, if an encoded data url is used. Example (from [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs):
```
data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E
```
should result in a HTML document with the following content:
```html
<h1>Hello, World!</h1>
```

Before this pull request, the .toBuffer() function would return a buffer which contains `%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`.

Now, the buffer equals `<h1>Hello, World!</h1>`.